### PR TITLE
fix: improve memory reading implementation

### DIFF
--- a/src/memory_reader/everest_reader.rs
+++ b/src/memory_reader/everest_reader.rs
@@ -16,48 +16,55 @@ pub(super) struct EverestMemReader {
 
 impl EverestMemReader {
     pub async fn new() -> Result<Option<Box<Self>>> {
+        loop {
+            if let Some(reader) = Self::scan_once().await? {
+                return Ok(Some(reader));
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    }
+
+    pub async fn scan_once() -> Result<Option<Box<Self>>> {
         const CORE_AUTOSPLITTER_MAGIC: &[u8] = b"EVERESTAUTOSPLIT\xF0\xF1\xF2\xF3";
         const CORE_AUTOSPLITTER_INFO_MIN_VERSION: u8 = 3;
-        loop {
-            let all_processes: Vec<Process> = procfs::process::all_processes()
-                .expect("Can't read /proc")
-                .filter_map(|p| match p {
-                    Ok(p) => {
-                        if p.stat().ok()?.comm.contains("Celeste") {
-                            return Some(p);
-                        }
-                        None
+        let all_processes: Vec<Process> = procfs::process::all_processes()
+            .expect("Can't read /proc")
+            .filter_map(|p| match p {
+                Ok(p) => {
+                    if p.stat().ok()?.comm.contains("Celeste") {
+                        return Some(p);
                     }
-                    Err(_) => None,
-                })
-                .collect();
-            for process in all_processes {
-                if let Ok(mut memory) = process.mem()
-                    && let Ok(maps) = process.maps()
-                {
-                    for map in maps {
-                        if map.perms.contains(MMPermissions::READ) {
-                            memory.seek(SeekFrom::Start(map.address.0))?;
-                            let mut buf: [u8; 20] = [0u8; 20];
-                            memory.read_exact(&mut buf).unwrap_or(());
-                            if buf.iter().eq(CORE_AUTOSPLITTER_MAGIC) {
-                                let mut buf2: [u8; 1] = [0];
-                                memory.seek(SeekFrom::Current(0x03))?;
-                                memory.read_exact(&mut buf2).unwrap_or(());
-                                if u8::from_be_bytes(buf2) < CORE_AUTOSPLITTER_INFO_MIN_VERSION {
-                                    continue;
-                                }
-                                return Ok(Some(Box::new(Self {
-                                    memory,
-                                    offset: map.address.0,
-                                })));
+                    None
+                }
+                Err(_) => None,
+            })
+            .collect();
+        for process in all_processes {
+            if let Ok(mut memory) = process.mem()
+                && let Ok(maps) = process.maps()
+            {
+                for map in maps {
+                    if map.perms.contains(MMPermissions::READ) {
+                        memory.seek(SeekFrom::Start(map.address.0))?;
+                        let mut buf: [u8; 20] = [0u8; 20];
+                        memory.read_exact(&mut buf).unwrap_or(());
+                        if buf.iter().eq(CORE_AUTOSPLITTER_MAGIC) {
+                            let mut buf2: [u8; 1] = [0];
+                            memory.seek(SeekFrom::Current(0x03))?;
+                            memory.read_exact(&mut buf2).unwrap_or(());
+                            if u8::from_be_bytes(buf2) < CORE_AUTOSPLITTER_INFO_MIN_VERSION {
+                                continue;
                             }
+                            return Ok(Some(Box::new(Self {
+                                memory,
+                                offset: map.address.0,
+                            })));
                         }
                     }
                 }
             }
-            tokio::time::sleep(Duration::from_millis(200)).await;
         }
+        Ok(None)
     }
 
     fn read_bits<const COUNT: usize>(&mut self, offset: u64) -> Result<[u8; COUNT]> {

--- a/src/memory_reader/game_data.rs
+++ b/src/memory_reader/game_data.rs
@@ -1,7 +1,5 @@
 use std::time::Duration;
 
-use tokio::select;
-
 use crate::split_reader::{Area, AreaMode};
 
 use super::everest_reader::EverestMemReader;
@@ -30,23 +28,21 @@ impl GameData {
         println!("Waiting for Celeste...");
         let mem_reader: Box<dyn MemReader>;
         loop {
-            select! {
-                res = VanillaMemReader::new(save_location.clone()) => {
-                    if let Ok(Some(reader)) = res {
-                        println!("Found Vanilla Celeste.");
-                        mem_reader = reader;
-                        break
-                    }
-                }
-                res = EverestMemReader::new() => {
-                    if let Ok(Some(reader)) = res {
-                        println!("Found Everest.");
-                        mem_reader = reader;
-                        break;
-                    }
-                }
-                _ = tokio::time::sleep(Duration::from_secs(5)) => {}
+            let res = VanillaMemReader::new(save_location.clone()).await;
+            if let Ok(Some(reader)) = res {
+                println!("Found Vanilla Celeste.");
+                mem_reader = reader;
+                break;
             }
+
+            let res = EverestMemReader::scan_once().await;
+            if let Ok(Some(reader)) = res {
+                println!("Found Everest.");
+                mem_reader = reader;
+                break;
+            }
+
+            tokio::time::sleep(Duration::from_secs(5)).await;
         }
         Self {
             mem_reader,

--- a/src/memory_reader/vanilla_reader.rs
+++ b/src/memory_reader/vanilla_reader.rs
@@ -20,13 +20,15 @@ pub(super) struct VanillaMemReader {
 static WARNED: AtomicBool = AtomicBool::new(false);
 
 impl VanillaMemReader {
+    const SCAN_CHUNK_SIZE: usize = 1024 * 1024;
+
     pub async fn new(save_location: String) -> Result<Option<Box<Self>>> {
         tokio::task::spawn_blocking(move || {
             let mut times: Vec<[u8; 8]> = Vec::with_capacity(3);
             for i in 0..3 {
                 let file_path = expand_tilde(&save_location)?.join(format!("{}.celeste", i));
                 if file_path.exists() {
-                    let t = fs::read_to_string(file_path)?;
+                    let t = fs::read_to_string(&file_path)?;
                     let u = Document::parse(t.as_str());
                     if let Ok(doc) = u {
                         for child in doc.get_node(NodeId::new(1)).unwrap().children() {
@@ -68,27 +70,43 @@ impl VanillaMemReader {
                             if map.pathname != MMapPath::Anonymous {
                                 continue;
                             }
-                            let size = (map.address.1 - map.address.0) as usize;
-                            let mut buf = vec![0u8; size];
+                            let mut overlap: Vec<u8> = Vec::new();
+                            let mut cursor = map.address.0;
+                            while cursor < map.address.1 {
+                                let remaining = (map.address.1 - cursor) as usize;
+                                let chunk_len = remaining.min(Self::SCAN_CHUNK_SIZE);
+                                let mut buf = vec![0u8; overlap.len() + chunk_len];
+                                buf[..overlap.len()].copy_from_slice(&overlap);
 
-                            memory.seek(SeekFrom::Start(map.address.0))?;
-                            if memory.read_exact(&mut buf).is_err() {
-                                continue;
-                            };
-                            for time in &times {
-                                let needle: [u8; 8] = *time;
-                                for i in (0..=buf.len() - 24).step_by(8) {
-                                    if buf[i..i + 8] == needle
-                                        && buf[i - 16..i].iter().all(|&b| b == 0)
-                                    {
-                                        let position = map.address.0 + i as u64;
-                                        return Ok(Some(Box::new(VanillaMemReader {
-                                            memory,
-                                            offset: position - 0x28,
-                                            last_file_time: f64::INFINITY,
-                                        })));
+                                memory.seek(SeekFrom::Start(cursor))?;
+                                if memory.read_exact(&mut buf[overlap.len()..]).is_err() {
+                                    break;
+                                }
+
+                                let scan_limit = buf.len().saturating_sub(24);
+                                for time in &times {
+                                    let needle: [u8; 8] = *time;
+                                    for i in (0..=scan_limit).step_by(8) {
+                                        if i < 16 {
+                                            continue;
+                                        }
+                                        if buf[i..i + 8] == needle
+                                            && buf[i - 16..i].iter().all(|&b| b == 0)
+                                        {
+                                            let position = cursor - overlap.len() as u64 + i as u64;
+                                            return Ok(Some(Box::new(VanillaMemReader {
+                                                memory,
+                                                offset: position - 0x28,
+                                                last_file_time: f64::INFINITY,
+                                            })));
+                                        }
                                     }
                                 }
+
+                                let keep = buf.len().min(32);
+                                overlap.clear();
+                                overlap.extend_from_slice(&buf[buf.len() - keep..]);
+                                cursor += chunk_len as u64;
                             }
                         }
                     }


### PR DESCRIPTION
### **These code changes were made by GPT 5.4 using Codex!!**

I don't have any rust experience, so I relied on AI for this. If you can, please review and check that everything looks and works fine on other installs. If you want to close this, I'd understand, however there's probably useful stuff here still.

## AI change summary

Summary

  This PR fixes vanilla Celeste detection on Linux when the autosplitter would otherwise stay stuck at Waiting for Celeste... even though the game process was running and readable.

  What Changed

  1. src/memory_reader/game_data.rs
     Detection no longer uses tokio::select! to race the vanilla reader, Everest reader, and a 5-second sleep.

     Instead, it:
      - awaits one vanilla detection attempt
      - awaits one Everest detection attempt
      - sleeps 5 seconds
      - repeats
  2. src/memory_reader/vanilla_reader.rs
     The vanilla memory scan now reads anonymous writable/private mappings in chunks instead of loading an entire mapping into memory at once.

     It also borrows the save file path when reading save XML and guards the i - 16 check during pattern matching.

  Why

  The root issue was cancellation.

  VanillaMemReader::new() uses spawn_blocking(). With the old select! logic, the sleep branch could win before the blocking scan finished. When that happened:

  - the future waiting for the scan result was dropped
  - the blocking scan kept running in the background
  - it could still find the autosplitter object
  - but its result was never delivered back to GameData
  - so the program stayed stuck at Waiting for Celeste...

  There was also a second practical issue in the vanilla scanner:

  - it read full memory mappings into a single buffer
  - on large mappings, that could stall detection badly or make it appear hung

  What Issues This Fixes

  - linsplit getting stuck forever at Waiting for Celeste... in vanilla Celeste
  - lost vanilla detection results caused by select! cancelling the in-flight scan
  - very slow or effectively hung vanilla memory scanning on large memory maps
  - a small correctness issue in the scan loop where buf[i - 16..i] could be indexed without checking i >= 16

